### PR TITLE
Bump to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.5.0:
+### Features
+- Implement READv2 kinship estimation method
 ## 0.4.4:
 ### Features
 - Add 'final-bams' keyword in `samples.yml` file, which allows the addition of fully pre-processed files at the pileup stage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.4.4:
+### Features
+- Add 'final-bams' keyword in `samples.yml` file, which allows the addition of fully pre-processed files at the pileup stage.
+
 ## 0.4.3:
 ### Breaking change(s)
 - Minimum supported snakemake version is now snakemake>=8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 0.4.3:
+### Breaking change(s)
+- Minimum supported snakemake version is now snakemake>=8
+
+### Features
+- (Breaking) added `path` entry to samples.yml. This allows users to specify custom paths for their R1 and R2 files, but changes the structure of the yaml, and forces the use of Snakemake
 ## 0.4.2:
 ### Features
 - Bump to snakemake-8+ (8.30.0). (Pipeline is still retrocompatible with snakemake>=7.20.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 0.4.2:
+### Features
+- Bump to snakemake-8+ (8.30.0). (Pipeline is still retrocompatible with snakemake>=7.20.0)
+### Fixes
+- Fix `pmd-mask-0.3.2` and `grups-rs-0.3.2` conda environments
+- Explicitly specify python3 instead of `python` in `get_bamlist_panel_coverage`
+
 ## 0.4.1:
 
 ### Features:

--- a/config/config.yml
+++ b/config/config.yml
@@ -139,7 +139,45 @@ kinship:
       - HG00101.SG
       - HG00102.SG
       - HG00103.SG
-      - HG00105.SG 
+      - HG00105.SG
+  READv2:                                      # ---- READv2 parameters
+    coverage-threshold: 10000                  # -- minimum number of non missing SNP targets required to include a
+                                               #    given sample within the analysis .
+                                               #    [<int> or "coverage"] (e.g.: 10000, "0.01X") 
+                                               #    -> integer values are interpreted as # of covered positions
+                                               #    -> suffix your value with 'X' to interpret it as coverage.
+                                               #
+    window-est:         False                  # -- Toggle legacy window-based estimate of P0. 
+                                               #    <bool> [True|False] (Default: False)
+                                               #
+    window-size:        1000000                # -- Default size of non-overlapping windows for the estimation of P0 
+                                               #    <int> (in base pairs) (Default: 1e6)
+                                               #
+    norm-method:        "median"               # -- READ Normalization method 
+                                               #    <str> [ median | mean | max | value ]
+                                               #
+    norm-value:         ~                      # -- Normalization value (Float). Ignored if norm-method != "value"
+                                               #    <float> (Default: None)
+                                               #
+    2pow:               False                  # -- Toggle alternate classification threshold
+                                               #    <bool> [True|False] (Default: False)
+                                               #      - When False: [0.96875,0.90625,0.8125,0.625]
+                                               #      - When True : [1-1/(2**4.5), 1-1/(2**3.5), 1-1/(2**2.5), 1-1/(2**1.5)]
+                                               #
+    add-proxies:        ~                      # -- Include additional 'proxy' individuals from the AADR 1240K dataset
+                                               #    within the input PLINK fileset. 
+                                               #    <str> [ "Reich" | None (~) ]
+                                               #
+    maf:                ~                      # -- Minor allele frequency filtration treshold (Float).
+                                               #    - Ignored if set to None (~)
+                                               #    - Requires caller="pileupCaller" and add-proxies="Reich". 
+                                               #    <float> (Default: 0.05)
+                                               #
+    proxies:            ~                      # -- Specify the sample-ids to fetch from the AADR dataset when
+                                               #    adding proxy individuals. Requires caller="pileupCaller" and 
+                                               #    add-proxies='Reich'
+                                               #    [<str>]
+                                               #
   GRUPS-rs:                                    # ---- GRUPS-rs parameters
     pedigree: |-                               # -- Path leading to a predefined template pedigree
       resources/grups-rs/template-pedigrees/siblings-pedigree.ped

--- a/config/netrules.yml
+++ b/config/netrules.yml
@@ -2,13 +2,13 @@
 netrules:
   reference-genomes:
     grch37:
-      url : "http://ftp.ensembl.org/pub/grch37/current/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.primary_assembly.fa.gz"
+      url : "ftp://ftp.ensembl.org/pub/grch37/current/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.primary_assembly.fa.gz"
       path: "data/reference-genome/GRCh37/Homo_sapiens.GRCh37.dna.primary_assembly.fa"
     hs37d5:
-      url : "http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+      url : "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
       path: "data/reference-genome/hs37d5/hs37d5.fa"
     human_g1k_v37:
-      url : "http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/human_g1k_v37.fasta.gz"
+      url : "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/human_g1k_v37.fasta.gz"
       path: "data/reference-genome/human_g1k_v37/human_g1k_v37.fasta"
   TKGWV2:
     support-files-url:       "https://drive.google.com/drive/folders/1Aw-0v_7CUorHJOLpCJ0QVCwEdH43HlO4"

--- a/config/samples.yml
+++ b/config/samples.yml
@@ -1,18 +1,34 @@
 # Instructions:
 # 
 # 1. Add fastq.gz files into a `original-data` directory, at the root of this repository.
-#    Directory structure must strictly follow the following nomenclature (see the README for an example)
-#    'original-data/samples/{sample-id}/{run-id}/{sample-id}_R{1,2}.fastq.gz'
-#
+# 
+#   - While custom paths to the files may be specified (see below) we highly recommend 
+#     that users structly  adhere to the following directory structure:
+# 
+#       > 'original-data/samples/{sample-id}/{run-id}/{sample-id}_R{1,2}.fastq.gz'
+# 
 # 2. Add target sample ids within this config file, under the 'samples' tag.
+#    - You may optionally provide custom paths to the R1 and R2 files, by specifying them inside a sample entry, 
+#      using the following structure:
+#
+#        > <sample-name>: {path:{r1: "path/to/R1.fq.gz", r2: "path/to/R2.fq.gz"}}
+#
+#    - If no file is provided for a given sample, Snakemake will then attempt to find matching files, using 
+#      the following directory structure:
+#
+#        > `original-data/samples/{sample-id}/{run-id}/{sample-id}_R{1,2}.fastq.gz`
+# 
+#    - Examples are provided below, and in the README.md file of this repository.
+# 
 # 3. Specify the name and protocol of each targeted sequencing-run for each sample. 
 #    Note that this pipeline can both handle paired-end and single-end sequencing protocols.
 samples:
-  test-ind1:
-    run-00: {protocol: 'paired'}
-    run-01: {protocol: 'paired'}
-  test-ind2:
-    run-00: {protocol: 'paired'}
-    run-01: {protocol: 'paired'}
-  test-ind3:
-    run-00: {protocol: 'paired'}
+  raw-fastq:
+    test-ind1:
+      run-00: {protocol: 'paired'}
+      run-01: {protocol: 'paired', path: {r1: "original-data/samples/test-ind1/run-01/test-ind1_R1.fastq.gz", r2: "original-data/samples/test-ind1/run-01/test-ind1_R2.fastq.gz"}}
+    test-ind2:
+      run-00: {protocol: 'paired'}
+      run-01: {protocol: 'paired'}
+    test-ind3:
+      run-00: {protocol: 'paired'}

--- a/config/samples.yml
+++ b/config/samples.yml
@@ -32,3 +32,7 @@ samples:
       run-01: {protocol: 'paired'}
     test-ind3:
       run-00: {protocol: 'paired'}
+  
+  final-bams:
+    test-ind4: {}
+    test-ind5: {path: "original-data/samples/final-bams/test-ind5.final.bam"}

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -2,7 +2,7 @@ configfile: "./config/config.yml"
 configfile: "./config/samples.yml"
 
 wildcard_constraints:
-    chr = "\d+",
+    chr = r"\d+",
 
 # ---- Generate a global metadata file. Keeps track of seeding values + commit hashes.
 checkpoint meta:
@@ -12,7 +12,7 @@ checkpoint meta:
 
 
 include: "rules/00-common.smk"
-include: "rules/00-netrules.smk"
+include: "rules/00-netrules/00-netrules.smk"
 include: "rules/00-preprocess-reference.smk"
 include: "rules/01-align-fastqs.smk"
 include: "rules/02-preprocess-bams.smk"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -19,6 +19,7 @@ include: "rules/02-preprocess-bams.smk"
 include: "rules/03-variant-calling.smk"
 include: "rules/04-merge-reich-plink.smk"
 include: "rules/05-READ.smk"
+include: "rules/05-READv2.smk"
 include: "rules/05-TKGWV2.smk"
 include: "rules/05-grups-rs.smk"
 include: "rules/05-KIN.smk"
@@ -64,6 +65,11 @@ rule READ:
         rules.READ_get_pairwise_snp_overlap.output,
         rules.READ_get_relatedness_coefficient.output
 
+rule READv2:
+    input:
+        rules.meta.output,
+        rules.run_READv2.output
+
 rule GRUPS:
     input:
         rules.run_GRUPS.output
@@ -84,6 +90,7 @@ rule all:
         rules.qc.output,
         rules.TKGWV2.input,
         rules.READ.input,
+        rules.READv2.input,
         rules.GRUPS.input,
         rules.KIN.input,
         

--- a/workflow/envs/READv2.post-deploy.sh
+++ b/workflow/envs/READv2.post-deploy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+
+#eval "$(conda shell.bash hook)"
+#conda activate $(basename "$(readlink -f ${BASH_SOURCE[0]%.post-deploy.sh})")
+
+cd $CONDA_PREFIX/bin
+
+git clone https://github.com/GuntherLab/READv2.git
+cd READv2
+git checkout 'READv2.00'
+
+cd $CONDA_PREFIX/bin
+cp READv2/READ2.py ./ 
+chmod +x READ2.py
+
+ln -s READ2.py READ2
+rm -rf ./READv2

--- a/workflow/envs/READv2.yml
+++ b/workflow/envs/READv2.yml
@@ -1,0 +1,12 @@
+name: READv2
+channels:
+  - conda-forge
+  - anaconda
+dependencies:
+  - conda-forge::python=3.7
+  - conda-forge::pandas=1.1.1
+  - conda-forge::matplotlib=3.5.3
+  - numpy>=1.18.3      # Documentation of READ specifies 1.18.3 for numpy, but it is now deprecated in conda     
+  - conda-forge::pip=22.3.1
+  - pip:
+    - plinkio>=0.9.8

--- a/workflow/envs/grups-rs-0.3.2.post-deploy.sh
+++ b/workflow/envs/grups-rs-0.3.2.post-deploy.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 VERSION="v0.3.2"
-REPO_URL="https://github.com/MaelLefeuvre/grups-rs.git"
+REPO_URL="https://github.com/MaelLefeuvre/grups-rs"
 
 REPO="$CONDA_PREFIX/$(basename ${REPO_URL%.git})"
 BUILD_DIR="${REPO}/target"
 
 cd $CONDA_PREFIX
-git clone $REPO_URL
+git clone --recursive $REPO_URL
 cd $REPO
 git checkout "$VERSION"
 
@@ -16,6 +16,5 @@ export CC="x86_64-conda-linux-gnu-gcc"
 CMAKE_C_FLAGS="-I./ -L./ -I$CONDA_PREFIX/include -L$CONDA_PREFIX/lib" \
 RUSTFLAGS="-Ctarget-cpu=native" cargo install --path . --root $CONDA_PREFIX
 
-# ---- grups.plot optional dependency
-#R --slave -e 'devtools::install("./grups.plots")'
+R --slave -e 'devtools::install("./grups.plots")'
 

--- a/workflow/envs/grups-rs-0.3.2.yml
+++ b/workflow/envs/grups-rs-0.3.2.yml
@@ -12,8 +12,6 @@ dependencies:
   - conda-forge::zlib>=1.2.13
   - conda-forge::zlib-ng>=2.0.6
   - conda-forge::libdeflate>=1.17
-# ---- grups.plots dependencies ---- # 
-#  - conda-forge::r-base>=4.1.2
-#  - conda-forge::r-devtools>=2.4.5
-#  - conda-forge::r-mass
-#  - conda-forge::r-matrix
+  - conda-forge::r-base>=4.1.2
+  - conda-forge::r-devtools>=2.4.5
+

--- a/workflow/envs/pmd-mask-0.3.2.yml
+++ b/workflow/envs/pmd-mask-0.3.2.yml
@@ -1,8 +1,9 @@
-name: pmd-mask
+name: pmd-mask-0.3.2
 channels:
   - conda-forge
 dependencies:
-  - conda-forge::rust=1.74
+  - conda-forge::rust>=1.81
+  - conda-forge::pkgconfig
   - conda-forge::zlib>=1.2.13
   - conda-forge::libcurl
   - conda-forge::cmake>=3.25
@@ -12,3 +13,5 @@ dependencies:
   - conda-forge::zlib>=1.2.13
   - conda-forge::zlib-ng>=2.0.6
   - conda-forge::libdeflate>=1.17
+  - bioconda::perl-findbin  # CentOS|RHEL7 compatibility
+  - bioconda::perl-ipc-cmd  # CentOS|RHEL7 compatibility

--- a/workflow/envs/snakemake-8.30.0.yml
+++ b/workflow/envs/snakemake-8.30.0.yml
@@ -1,0 +1,8 @@
+name: snakemake-8.30.0
+channels:
+    - bioconda
+    - conda-forge
+dependencies:
+    - bioconda::snakemake=8.30.0
+    - bioconda::snakemake-storage-plugin-http
+    - bioconda::snakemake-storage-plugin-ftp

--- a/workflow/rules/00-common.smk
+++ b/workflow/rules/00-common.smk
@@ -40,6 +40,8 @@ def get_requested_sample_runs(wildcards):
 _DEFAULT_FASTQ_R1 = "original-data/samples/{sample}/{run}/{sample}_R1.fastq.gz"
 _DEFAULT_FASTQ_R2 = "original-data/samples/{sample}/{run}/{sample}_R2.fastq.gz"
 
+DEFAULT_FINAL_BAM = "original-data/samples/final-bams/{sample}.final.bam"
+
 def get_fastq_sample_path(wildcards):
     sample = config["samples"]["raw-fastq"][wildcards.sample][wildcards.run]
     if "path" not in sample or sample["path"] is None:

--- a/workflow/rules/00-common.smk
+++ b/workflow/rules/00-common.smk
@@ -26,16 +26,29 @@ class ReferenceGenome:
             print(f" - {key}")
 
 
-
-
 def get_sample_names():
-    return [key for key in config["samples"].keys()]
+    # Order guaranteed to reflect the order of insertion, as of Python3.7+
+    return [key for key in config["samples"]["raw-fastq"].keys()]
 
 def get_illumina_protocol(wildcards):
-    return config["samples"][wildcards.sample][wildcards.run]["protocol"]
+    return config["samples"]["raw-fastq"][wildcards.sample][wildcards.run]["protocol"]
 
 def get_requested_sample_runs(wildcards):
-    return [key for key in config["samples"][wildcards.sample].keys()]
+    return [key for key in config["samples"]["raw-fastq"][wildcards.sample].keys()]
+
+
+_DEFAULT_FASTQ_R1 = "original-data/samples/{sample}/{run}/{sample}_R1.fastq.gz"
+_DEFAULT_FASTQ_R2 = "original-data/samples/{sample}/{run}/{sample}_R2.fastq.gz"
+
+def get_fastq_sample_path(wildcards):
+    sample = config["samples"]["raw-fastq"][wildcards.sample][wildcards.run]
+    if "path" not in sample or sample["path"] is None:
+        sample["path"] = {
+            "r1" : _DEFAULT_FASTQ_R1,
+            "r2" : None if sample["protocol"] == "single" else _DEFAULT_FASTQ_R2
+        } 
+    return sample["path"]
+
 
 def resolve_aadr_version():
     """

--- a/workflow/rules/00-netrules/00-netrules-7.smk
+++ b/workflow/rules/00-netrules/00-netrules-7.smk
@@ -1,0 +1,12 @@
+from snakemake.remote.HTTP import RemoteProvider as HTTPRemoteProvider
+from snakemake.remote.FTP import RemoteProvider as FTPRemoteProvider
+class Storage:
+    def __init__(self):
+        self._HTTP= HTTPRemoteProvider()
+        self._FTP = FTPRemoteProvider()
+    def http(self, *args, **kwargs):
+        return self._HTTP.remote(*args, **kwargs)
+    def ftp(self, *args, **kwargs):
+        return self._FTP.remote(*args, **kwargs)
+
+storage = Storage()

--- a/workflow/rules/00-netrules/00-netrules-8.smk
+++ b/workflow/rules/00-netrules/00-netrules-8.smk
@@ -1,0 +1,9 @@
+storage:
+    provider = "http",
+    max_requests_per_second=10
+storage http:
+    provider = "http",
+    max_requests_per_second=10
+storage ftp:
+    provider = "ftp",
+    max_requests_per_second=10

--- a/workflow/rules/01-align-fastqs.smk
+++ b/workflow/rules/01-align-fastqs.smk
@@ -26,9 +26,8 @@ rule adapter_removal_pe:
     workflows, we don't output a combined fq file, to allow specific mapping using bwa aln.
     """
     input:
+        unpack(get_fastq_sample_path),
         meta        = rules.meta.output,
-        forwd       = "original-data/samples/{sample}/{run}/{sample}_R1.fastq.gz",
-        revrs       = "original-data/samples/{sample}/{run}/{sample}_R2.fastq.gz",
         metadata    = "results/meta/pipeline-metadata.yml",
     output:
         trimmed     = temp("results/01-preprocess/01-adapter_removal/{sample}/{run}/{sample}.collapsed.gz"),
@@ -52,8 +51,8 @@ rule adapter_removal_pe:
     shell: """
         AdapterRemoval \
         --threads {threads} \
-        --file1 {input.forwd} \
-        --file2 {input.revrs} \
+        --file1 {input.r1} \
+        --file2 {input.r2} \
         --basename {params.base_name} \
         --minlength {params.min_length} \
         --minquality {params.min_quality} \
@@ -71,7 +70,7 @@ rule adapter_removal_se:
     workflows, we don't output a combined fq file, to allow specific mapping using bwa aln.
     """
     input:
-        fastq       = "original-data/samples/{sample}/{run}/{sample}_R1.fastq.gz",
+        unpack(get_fastq_sample_path),
         metadata    = rules.meta.output,
     output:
         truncated   = temp("results/01-preprocess/01-adapter_removal/{sample}/{run}/{sample}.truncated.gz"),
@@ -91,7 +90,7 @@ rule adapter_removal_se:
     shell: """
         AdapterRemoval \
         --threads {threads} \
-        --file1 {input.fastq} \
+        --file1 {input.r1} \
         --basename {params.base_name} \
         --minlength {params.min_length} \
         --minquality {params.min_quality} \

--- a/workflow/rules/03-variant-calling.smk
+++ b/workflow/rules/03-variant-calling.smk
@@ -120,7 +120,7 @@ rule get_bamlist_panel_coverage:
         panel_size=$(cat {input.targets} | wc -l)
         for bam in $(cat {input.bamlist}); do
             depth=$(samtools depth -@ {threads} -b {input.targets} $bam | awk '($3>0)' | wc -l);
-            coverage=$(python -c "print(${{depth}}/${{panel_size}})")
+            coverage=$(python3 -c "print(${{depth}}/${{panel_size}})")
             echo -e ${{bam}}"\t"${{depth}}\t${{coverage}};
         done | sort -h -k2 | column -t > {output.coverage} 2> {log}
     """
@@ -238,7 +238,7 @@ rule ANGSD_haplo_to_plink:
     benchmark: "benchmarks/02-variant-calling/ANGSD_haplo_to_plink.tsv"
     conda:     "../envs/angsd-0.939.yml"
     priority:  15
-    shell: """
+    shell: r"""
         haploToPlink {input.haplos} {params.outputname} 2>  {log}
         sed -i 's/N/0/g' {output.tped}                  2>> {log}
         cat {input.bamlist} \

--- a/workflow/rules/05-READ.smk
+++ b/workflow/rules/05-READ.smk
@@ -136,7 +136,7 @@ rule run_READ:
     log:       "logs/03-kinship/READ/run_READ.log"
     benchmark: "benchmarks/03-kinship/READ/run_READ.tsv"
     conda:     "../envs/READ-1.0.yml"
-    shell: """
+    shell: r"""
         cwd=$(pwd)
         cd $(dirname {output.results})               2>  $cwd/{log}
         ln -srf $(which READscript.R) READscript.R   2>> $cwd/{log}
@@ -168,7 +168,7 @@ rule READ_get_relatedness_coefficient:
     output:
         relatedness = "results/03-kinship/READ/READ_relatedness_coefficients.txt"
     log: "logs/03-kinship/READ/READ_get_relatedness_coefficient.log"
-    shell: """
+    shell: r"""
         export LC_NUMERIC="en_US.UTF-8"
         sed 's/ /\t/g' {input.means} \
         | join -j1 -t$'\t' - {input.results} \

--- a/workflow/rules/05-READv2.smk
+++ b/workflow/rules/05-READv2.smk
@@ -1,0 +1,200 @@
+def READv2_define_random_haploid_caller(wildcards):
+    """
+    Define the input for READ, based on which variant-calling method was 
+    requested by the user.
+    """
+
+    variant_caller = config['variant-calling']['caller']
+    use_proxies    = config['kinship']['READv2']['add-proxies']
+    maf            = config['kinship']['READv2']['maf']
+
+    if use_proxies == "Reich" and variant_caller != 'pileupCaller':
+        raise RuntimeError("[ERROR]: Cannot use proxy individuals from Reich compendium if variant-caller is not set to pileupCaller.")
+
+    match config['variant-calling']['caller']:
+        case "ANGSD":
+            basefile = "results/02-variant-calling/02-ANGSD/samples"
+        case "pileupCaller":
+            if use_proxies == "Reich":
+                if maf is not None:
+                    basefile = "results/02-variant-calling/03-merged-reich/v{major}.{minor}_1240K_public-merged-samples-autosomes-maf{maf}-reqsamples".format(
+                        maf=str(maf),
+                        **resolve_aadr_version()
+                        )
+                else:
+                    basefile = "results/02-variant-calling/03-merged-reich/v{major}.{minor}_1240K_public-merged-samples-autosomes-reqsamples".format(
+                        **resolve_aadr_version()
+                    )
+            else:
+                basefile = "results/02-variant-calling/02-pileupCaller/samples"
+        case other:
+            raise RuntimeError(f"Incorrect pileupCaller mode selected: '{other}'")
+
+    return multiext(basefile, ".bed", ".bim", ".fam")
+
+def get_coverage_threshold(wildcards):
+    threshold = config['kinship']['READ']['coverage-threshold']
+    if str(threshold).endswith('X'):
+        threshold = threshold[:-1]
+    
+    return threshold
+
+
+def get_coverage_column(wildcards):
+    threshold = str(config['kinship']['READ']['coverage-threshold'])
+    return 3 if threshold.endswith('X') else 2
+
+
+rule READv2_filter_low_coverage_samples:
+    input:
+        meta     = rules.meta.output,
+        coverage = rules.get_bamlist_panel_coverage.output.coverage,
+        tplink   = READv2_define_random_haploid_caller
+    output:
+        excluded_samples = "results/03-kinship/READv2/excluded-samples.txt",
+        bfile           = multiext("results/03-kinship/READv2/READv2-input-filtered", ".bed", ".bim", ".fam")
+    params:
+        coverage_threshold = get_coverage_threshold,
+        coverage_column    = get_coverage_column,
+        sample_names       = get_sample_names(),
+        input_basename     = lambda wildcards, input: splitext(input.tplink[0])[0],
+        output_basename    = lambda wildcards, output: splitext(output.bfile[0])[0],
+        sample_pop_name   = config['variant-calling']['sample-pop-name'],
+        optargs           = assign_plink_optargs
+
+    log:       "logs/03-kinship/READ/filter_low_coverage_samples.log"
+    benchmark: "benchmarks/03-kinship/READ/filter_low_coverage_samples.tsv"
+    conda:     "../envs/plink-1.9.yml"
+    threads: 1
+    shell: """
+        # Get a list of individuals not meeting the threshold
+        # Note that 'cut -f1 -d. ' implies sample_names containing '.' characters is undefined behavior...
+        # trailing grep commands with test $? = 1 ensures non-match is not interpreted as an error.
+        LC_ALL="C" awk '${params.coverage_column}<{params.coverage_threshold}' {input.coverage} \
+        | {{ grep -P "$(echo {params.sample_names} | tr ' ' '|')" || test $? = 1; }} \
+        | cut -f1 -d' ' \
+        | {{ grep -o '[^/]*$' || test $? = 1; }} \
+        | cut -f1 -d"." \
+        | sort -u \
+        > {output.excluded_samples} 2>> {log}
+
+        # Add population names
+        sed -i -E 's/^(.+)/{params.sample_pop_name} \\1/' {output.excluded_samples} >> {log} 2>&1
+
+        if [ -s {output.excluded_samples} ]; then
+            plink --threads {threads} {params.optargs} \
+            --tfile {params.input_basename} \
+            --remove {output.excluded_samples} \
+            --make-bed \
+            --out {params.output_basename} \
+            > {log} 2>&1
+        else
+            plink --threads {threads} {params.optargs} \
+            --bfile {params.input_basename} \
+            --make-bed \
+            --out {params.output_basename} \
+            > {log} 2>&1
+        fi
+    """
+
+
+
+
+def get_READv2_norm_value(wildcards):
+    """
+    Inject the user-defined normalization value within READ's command line 
+    arguments (if the user requested it). Or add a placeholder "-" character
+    in place if the user wishes to compute that value from the cohort.
+    """
+    if config["kinship"]["READ"]["norm-method"] == "value":
+        return config["kinship"]["READ"]["norm-value"]
+    else:
+        return "-"
+
+# ------------------------------------------------------------------------------------------------------------------- #
+# ---- READ
+
+def parse_READv2_norm_method(wildcards):
+    """
+    Get user-defined normalization value within READv2' command line argument
+    If the user requested it.
+    """
+    norm_method = config['kinship']['READv2']['norm-method']
+    norm_value  = config['kinship']['READv2']['norm-value']
+    match norm_method:
+        case None:
+            return ""
+        case "median" | "mean" | "max":
+            return f"--norm_method {norm_method}"
+        case "value":
+            if norm_value is None:
+                raise RuntimeError("[READv2]: requested a set normalisation value, but none provided")
+            return f"--norm_method value --norm_value {config['kinship']['READv2']['norm-value']}"
+        case other:
+            raise RuntimeError(f"[READv2]: Invalid norm-method: {other}")
+
+def parse_READv2_window_estimate(wildcards):
+    """
+    Add user-defined window estimate strategy within READv2' command line argument
+    if the user requested it.
+    """
+    output_optargs            = ""
+    window_size               = config['kinship']['READv2']['window-size']
+    window_estimate_requested = config['kinship']['READv2']['window-est']
+    if window_estimate_requested:
+        output_optargs += "--window_est"
+        if window_size is not None:
+            try:
+                output_optargs += f" --window_size {int(window_size)}"
+            except:
+                raise RuntimeError(f"[READv2]: Invalid window-size provided: {window_size}")
+    return output_optargs
+
+def parse_READv2_alternate_thresholds(wildcards):
+    """
+    Inject the user-requested window threshold stragtegy within READv2's command line argument
+
+    - When False: [0.96875,0.90625,0.8125,0.625]
+    - When True:  [1-1/(2**4.5),1-1/(2**3.5),1-1/(2**2.5),1-1/(2**1.5)]
+    """
+    alternate_threshold_requested = config['kinship']['READv2']['2pow']
+    return "--2pow" if alternate_threshold_requested else ""
+
+
+def count_comparisons(wildcards, include_self = False):
+    with open(rules.generate_bam_list.output.bamlist) as f:
+        n = len([line for line in f.readlines()])
+        combinations = (n * (n-1)) / 2
+    return combinations + n if include_self else combinations
+
+# ------------------------------------------------------------------------------------------------ #
+
+rule run_READv2:
+    """
+    Run the updated version of READ
+    Citation: Alaçamlı, E., Naidoo, T., Güler, M.N. et al. READv2: advanced and user-friendly
+              detection of biological relatedness in archaeogenomics. Genome Biol 25, 216 (2024).
+              https://doi.org/10.1186/s13059-024-03350-3
+    Github:   https://github.com/GuntherLab/READv2
+    """
+    input:
+        bfile   = rules.READv2_filter_low_coverage_samples.output.bfile
+    output:
+        results = "results/03-kinship/READv2/Read_Results.tsv",
+        means   = "results/03-kinship/READv2/meansP0_AncientDNA_normalized_READv2",
+        #plot    = "results/03-kinship/READv2/READ.pdf",
+    params:
+        norm_method   = parse_READv2_norm_method,
+        window_size   = parse_READv2_window_estimate,
+        alt_threshold = parse_READv2_alternate_thresholds,
+        basename      = lambda wildcards, input: splitext(input.bfile[0])[0],
+    log:       "logs/03-kinship/READv2/run_READv2.log"
+    benchmark: "benchmarks/03-kinship/READv2/run_READv2.tsv"
+    conda:     "../envs/READv2.yml"
+    shell: r"""
+        cwd=$(pwd)
+        cd $(dirname {output.results}) > $cwd/{log} 2>&1
+        READ2 --input $cwd/{params.basename} \
+        {params.norm_method} {params.window_size} {params.alt_threshold} \
+        >> $cwd/{log} 2>&1
+    """


### PR DESCRIPTION
<ins><b>Changes</b></ins>:
* **[Breaking]**: Bump minimum supported snakemake version to `snakemake-8.30.0`

<ins><b>New features</b></ins>:
* Implement READv2
* Allow the inclusion of fully pre-processed bam when performing kinship analysis, during the pileup stage.
* Allow the specification of user-defined paths in the `samples.yml` configuration file

<ins><b>Fixes</b></ins>:
* Fix `pmd-mask` and `grups-rs` conda environments
* Explicitly specify `python3` instead of `python` within rule `get_bamlist_panel_coverage`
